### PR TITLE
Correctly reflect unknown lag in graph

### DIFF
--- a/lageffect.R
+++ b/lageffect.R
@@ -19,7 +19,7 @@ data <- dbGetQuery(db, "
     report_date,
     death_date,
     deaths,
-    CASE WHEN report_date > MIN(report_date) OVER () THEN report_date - death_date ELSE 0 END AS lag_effect,
+    CASE WHEN report_date > MIN(report_date) OVER () THEN report_date - death_date END AS lag_effect,
     deaths - COALESCE(LAG(deaths) OVER (PARTITION BY death_date ORDER BY report_date),0) AS new_deaths
   FROM deaths
 ")
@@ -48,10 +48,10 @@ plot2 <- ggplot(data, aes(x=death_date)) +
   labs(x = "Datum avliden", color = "Rapportdatum", y = "Antal avlidna")
 
 data$lag_effect <- pmin(7, data$lag_effect)
-data$lag_effect <-  as.factor(data$lag_effect)
+data$lag_effect <- factor(data$lag_effect, levels = sort(unique(data$lag_effect), decreasing = TRUE))
 
 plot3 <- ggplot(data, aes(x=death_date)) +
-  geom_col(aes(y=new_deaths, fill=lag_effect), position = position_stack(reverse = TRUE)) +
+  geom_col(aes(y=new_deaths, fill=lag_effect), position = position_stack()) +
   theme_minimal() +
   labs(x = "Datum avliden", fill = "Eftersläpning", y = "Antal avlidna") +
   ggtitle("Folkhälsomyndigheten - Covid19 - Avlidna per dag") +


### PR DESCRIPTION
Since we are missing data from before 2020-04-03 in our dataset we have
no way of knowing when most of the deaths before that date were reported
and tht should be reflected in the graph somehow.

Before this commit the deaths represented at an unknown date were
graphed with a lag of zero. This commit changes that to a lag of NA
which removes a potentially missleading thing in the graph.

As a side effect this commit reverses the colors of the graph, but it
should be just as readable.